### PR TITLE
Feature: hide files and folders

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,7 @@ include_directories(
 )
 
 TARGET_LINK_LIBRARIES (Nextcloud.app PRIVATE inkview freetype curl sqlite3 stdc++fs)
+target_compile_definitions(Nextcloud.app PRIVATE DBVERSION=2 PROGRAMVERSION="1.02")
 
 INSTALL (TARGETS Nextcloud.app)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ set(SOURCES ${CMAKE_SOURCE_DIR}/src/main.cpp
 			${CMAKE_SOURCE_DIR}/src/handler/contextMenu.cpp
 			${CMAKE_SOURCE_DIR}/src/handler/eventHandler.cpp
 			${CMAKE_SOURCE_DIR}/src/handler/mainMenu.cpp
+            ${CMAKE_SOURCE_DIR}/src/handler/fileHandler.cpp
             ${CMAKE_SOURCE_DIR}/src/ui/listView.cpp
 			${CMAKE_SOURCE_DIR}/src/ui/listViewEntry.cpp
             ${CMAKE_SOURCE_DIR}/src/ui/webDAVView/webDAVView.cpp
@@ -59,6 +60,7 @@ set(SOURCES ${CMAKE_SOURCE_DIR}/src/main.cpp
 			${CMAKE_SOURCE_DIR}/src/ui/loginView/loginView.cpp
             ${CMAKE_SOURCE_DIR}/src/ui/fileView/fileView.cpp
             ${CMAKE_SOURCE_DIR}/src/ui/fileView/fileViewEntry.cpp
+            ${CMAKE_SOURCE_DIR}/src/ui/excludeFileView/excludeFileView.cpp
 			${CMAKE_SOURCE_DIR}/src/util/util.cpp
 			${CMAKE_SOURCE_DIR}/src/util/log.cpp
             ${CMAKE_SOURCE_DIR}/src/api/webDAV.cpp
@@ -78,6 +80,7 @@ include_directories(
     ${CMAKE_SOURCE_DIR}/src/ui/webDAVView/
     ${CMAKE_SOURCE_DIR}/src/ui/fileView/
     ${CMAKE_SOURCE_DIR}/src/ui/loginView/
+    ${CMAKE_SOURCE_DIR}/src/ui/excludeFileView/
     ${CMAKE_SOURCE_DIR}/src/api/
 )
 

--- a/src/api/fileBrowser.h
+++ b/src/api/fileBrowser.h
@@ -11,9 +11,11 @@
 #define FILEBROWSER
 
 #include "fileModel.h"
+#include "fileHandler.h"
 
 #include <string>
 #include <vector>
+#include <memory>
 
 class FileBrowser
 {
@@ -22,6 +24,8 @@ class FileBrowser
 
     private:
         FileBrowser(){};
+
+        static std::shared_ptr<FileHandler> _fileHandler;
 
 };
 #endif

--- a/src/api/sqliteConnector.cpp
+++ b/src/api/sqliteConnector.cpp
@@ -21,6 +21,12 @@ using std::string;
 SqliteConnector::SqliteConnector(const string &DBpath) : _dbpath(DBpath)
 {
      _fileHandler = std::shared_ptr<FileHandler>(new FileHandler());
+
+     // check if migration has to be run
+    int currentVersion = getDbVersion();
+    if (currentVersion != DBVERSION) {
+        runMigration(currentVersion);
+    }
 }
 
 SqliteConnector::~SqliteConnector()
@@ -28,6 +34,74 @@ SqliteConnector::~SqliteConnector()
     sqlite3_close(_db);
     _fileHandler.reset();
     Log::writeInfoLog("closed DB");
+}
+
+void SqliteConnector::runMigration(int currentVersion) 
+{
+    open();
+
+    char* log;
+    sprintf(log, "Running migration from db version %i to %i (Program version %s)", currentVersion, DBVERSION, PROGRAMVERSION);
+    Log::writeInfoLog(log);
+
+    // currently there are no migrations
+
+    // updating to current version
+    int rs;
+    sqlite3_stmt *stmt = 0;
+
+    rs = sqlite3_prepare_v2(_db, "INSERT INTO 'version' (dbversion) VALUES (?)", -1, &stmt, 0);
+    rs = sqlite3_bind_int(stmt, 1, DBVERSION);
+
+    rs = sqlite3_step(stmt);
+    if (rs != SQLITE_DONE) {
+        // this is critical
+        Log::writeErrorLog(std::string("error inserting into version") + sqlite3_errmsg(_db) + std::string(" (Error Code: ") + std::to_string(rs) + ")");
+    }
+
+    sqlite3_finalize(stmt);
+    sqlite3_close(_db);
+}
+
+int SqliteConnector::getDbVersion() 
+{
+    open();
+
+    int rs;
+    sqlite3_stmt *stmt = 0;
+    
+    int version;
+    rs = sqlite3_prepare_v2(_db, "SELECT MAX(dbversion) FROM 'version'", -1, &stmt, 0);
+    while (sqlite3_step(stmt) == SQLITE_ROW)
+    {
+        version = sqlite3_column_int(stmt, 0);
+    }
+
+    if (version != 0)
+    {
+        sqlite3_finalize(stmt);
+        sqlite3_close(_db);
+        return version;
+    } else {
+        // this is probably the first start -> the version is up to date and insert the current version
+        rs = sqlite3_prepare_v2(_db, "INSERT INTO 'version' (dbversion) VALUES (?)", -1, &stmt, 0);
+        rs = sqlite3_bind_int(stmt, 1, DBVERSION);
+
+        rs = sqlite3_step(stmt);
+        if (rs != SQLITE_DONE) {
+            Log::writeErrorLog(std::string("error inserting into version") + sqlite3_errmsg(_db) + std::string(" (Error Code: ") + std::to_string(rs) + ")");
+        }
+        rs = sqlite3_clear_bindings(stmt);
+        rs = sqlite3_reset(stmt);
+
+        // for compatibility alter the table because at this point db migrations doesn't exist
+        rs = sqlite3_exec(_db, "ALTER TABLE metadata ADD hide INT DEFAULT 0 NOT NULL", NULL, 0, NULL);
+
+        sqlite3_finalize(stmt);
+        sqlite3_close(_db);
+
+        return DBVERSION;
+    }
 }
 
 bool SqliteConnector::open()
@@ -42,7 +116,8 @@ bool SqliteConnector::open()
         return false;
     }
 
-    rs = sqlite3_exec(_db, "CREATE TABLE IF NOT EXISTS metadata (title VARCHAR, localPath VARCHAR, size VARCHAR, fileType VARCHAR, lasteditDate VARCHAR, type INT, state INT, etag VARCHAR, path VARCHAR PRIMARY KEY, parentPath VARCHAR)", NULL, 0, NULL);
+    rs = sqlite3_exec(_db, "CREATE TABLE IF NOT EXISTS metadata (title VARCHAR, localPath VARCHAR, size VARCHAR, fileType VARCHAR, lasteditDate VARCHAR, type INT, state INT, etag VARCHAR, path VARCHAR PRIMARY KEY, parentPath VARCHAR, hide INT DEFAULT 0 NOT NULL)", NULL, 0, NULL);
+    rs = sqlite3_exec(_db, "CREATE TABLE IF NOT EXISTS version (dbversion INT)", NULL, 0, NULL);
 
     return true;
 }
@@ -123,13 +198,16 @@ std::vector<WebDAVItem> SqliteConnector::getItemsChildren(const string &parentPa
     int rs;
     sqlite3_stmt *stmt = 0;
     std::vector<WebDAVItem> items;
-    std::vector<WebDAVItem> itemsToRemove;
 
-    rs = sqlite3_prepare_v2(_db, "SELECT title, localPath, path, size, etag, fileType, lastEditDate, type, state FROM 'metadata' WHERE path=? OR parentPath=? ORDER BY parentPath;", -1, &stmt, 0);
+    rs = sqlite3_prepare_v2(
+        _db, 
+        "SELECT title, localPath, path, size, etag, fileType, lastEditDate, type, state, hide FROM 'metadata' WHERE (path=? OR parentPath=?) AND hide <> 2 ORDER BY parentPath;", 
+        -1, &stmt, 0
+    );
     rs = sqlite3_bind_text(stmt, 1, parentPath.c_str(), parentPath.length(), NULL);
     rs = sqlite3_bind_text(stmt, 2, parentPath.c_str(), parentPath.length(), NULL);
 
-    const int storageLocationLength = (NEXTCLOUD_ROOT_PATH + _fileHandler->getStorageUsername() + "/").length();
+    const string storageLocation = NEXTCLOUD_ROOT_PATH + _fileHandler->getStorageUsername() + "/";
     while (sqlite3_step(stmt) == SQLITE_ROW)
     {
         WebDAVItem temp;
@@ -143,6 +221,7 @@ std::vector<WebDAVItem> SqliteConnector::getItemsChildren(const string &parentPa
         temp.lastEditDate = Util::webDAVStringToTm(reinterpret_cast<const char *>(sqlite3_column_text(stmt, 6)));
         temp.type =  static_cast<Itemtype>(sqlite3_column_int(stmt,7));
         temp.state =  static_cast<FileState>(sqlite3_column_int(stmt,8));
+        temp.hide =  static_cast<HideState>(sqlite3_column_int(stmt,9));
 
         if (iv_access(temp.localPath.c_str(), W_OK) != 0)
         {
@@ -150,32 +229,14 @@ std::vector<WebDAVItem> SqliteConnector::getItemsChildren(const string &parentPa
                 temp.state = FileState::ICLOUD;
         }
 
-        string direcotryPath = temp.path;
-        if (direcotryPath.length() >= storageLocationLength) {
-            direcotryPath = direcotryPath.substr(storageLocationLength);
+        if (temp.hide == HideState::INOTDEFINED) {
+            temp.hide = _fileHandler->getHideState(temp.type, storageLocation, temp.path, temp.title);
         }
-        if (temp.type == Itemtype::IFILE && ( _fileHandler->excludeFolder(direcotryPath) || _fileHandler->excludeFile(temp.title))) {
-            //The file was previously cached and should be excluded from now on
-            //TODO Maybe an SQL statement with REGEX match should be executed directly after changing the conifg
-            itemsToRemove.push_back(temp);
-        } else if (temp.type == Itemtype::IFOLDER && _fileHandler->excludeFolder(direcotryPath)) {
-            itemsToRemove.push_back(temp);
-        } 
-        else {
-            items.push_back(temp);
-        }
+        items.push_back(temp);
     }
 
     sqlite3_finalize(stmt);
     sqlite3_close(_db);
-
-    for (WebDAVItem itemD : itemsToRemove) {
-        if (itemD.type == Itemtype::IFOLDER) {
-            deleteChildren(itemD.path);
-        } else {
-            deleteChild(itemD.path, itemD.title);
-        }
-    }
 
     return items;
 }
@@ -197,6 +258,28 @@ void SqliteConnector::deleteChild(const string &path, const string &title)
     rs = sqlite3_clear_bindings(stmt);
     rs = sqlite3_reset(stmt);
 
+}
+
+bool SqliteConnector::resetHideState()
+{
+    open();
+    int rs;
+    sqlite3_stmt *stmt = 0;
+
+    rs = sqlite3_prepare_v2(_db, "UPDATE 'metadata' SET hide=0", -1, &stmt, 0);
+    rs = sqlite3_step(stmt);
+
+    if (rs != SQLITE_DONE)
+    {
+        Log::writeErrorLog(sqlite3_errmsg(_db) + std::string(" (Error Code: ") + std::to_string(rs) + ")");
+    }
+    rs = sqlite3_clear_bindings(stmt);
+    rs = sqlite3_reset(stmt);
+
+    sqlite3_finalize(stmt);
+    sqlite3_close(_db);
+
+    return true;
 }
 
 void SqliteConnector::deleteChildren(const string &parentPath)
@@ -232,7 +315,7 @@ bool SqliteConnector::saveItemsChildren(const std::vector<WebDAVItem> &items)
 
     for (auto item : items)
     {
-        rs = sqlite3_prepare_v2(_db, "INSERT INTO 'metadata' (title, localPath, path, size, parentPath, etag, fileType, lastEditDate, type, state) VALUES (?,?,?,?,?,?,?,?,?,?);", -1, &stmt, 0);
+        rs = sqlite3_prepare_v2(_db, "INSERT INTO 'metadata' (title, localPath, path, size, parentPath, etag, fileType, lastEditDate, type, state, hide) VALUES (?,?,?,?,?,?,?,?,?,?,?);", -1, &stmt, 0);
         rs = sqlite3_exec(_db, "BEGIN TRANSACTION;", NULL, NULL, NULL);
         rs = sqlite3_bind_text(stmt, 1, item.title.c_str(), item.title.length(), NULL);
         rs = sqlite3_bind_text(stmt, 2, item.localPath.c_str(), item.localPath.length(), NULL);
@@ -245,6 +328,7 @@ bool SqliteConnector::saveItemsChildren(const std::vector<WebDAVItem> &items)
         rs = sqlite3_bind_text(stmt, 8, lastEditDateString.c_str(), lastEditDateString.length(), NULL);
         rs = sqlite3_bind_int(stmt, 9, item.type);
         rs = sqlite3_bind_int(stmt, 10, item.state);
+        rs = sqlite3_bind_int(stmt, 11, item.hide);
 
         rs = sqlite3_step(stmt);
         if (rs == SQLITE_CONSTRAINT)

--- a/src/api/sqliteConnector.h
+++ b/src/api/sqliteConnector.h
@@ -12,9 +12,12 @@
 
 #include "webDAVModel.h"
 #include "sqlite3.h"
+#include "fileHandler.h"
 
 #include <string>
 #include <vector>
+
+#include <memory>
 
 class SqliteConnector
 {
@@ -38,11 +41,15 @@ public:
 
     void deleteChildren(const std::string &parentPath);
 
+    void deleteChild(const std::string &path, const std::string &title);
+
     bool saveItemsChildren(const std::vector<WebDAVItem> &children);
 
 private:
     std::string _dbpath;
     sqlite3 *_db;
+
+    std::shared_ptr<FileHandler> _fileHandler;
 };
 
 #endif

--- a/src/api/sqliteConnector.h
+++ b/src/api/sqliteConnector.h
@@ -32,7 +32,7 @@ public:
     bool open();
 
     int getDbVersion();
-    
+
     void runMigration(int currentVersion);
 
     std::string getEtag(const std::string &path);
@@ -46,6 +46,8 @@ public:
     void deleteChildren(const std::string &parentPath);
 
     void deleteChild(const std::string &path, const std::string &title);
+
+    void deleteItemsNotBeginsWith(std::string beginPath);
 
     bool resetHideState();
 

--- a/src/api/sqliteConnector.h
+++ b/src/api/sqliteConnector.h
@@ -31,6 +31,10 @@ public:
 
     bool open();
 
+    int getDbVersion();
+    
+    void runMigration(int currentVersion);
+
     std::string getEtag(const std::string &path);
 
     FileState getState(const std::string &path);
@@ -42,6 +46,8 @@ public:
     void deleteChildren(const std::string &parentPath);
 
     void deleteChild(const std::string &path, const std::string &title);
+
+    bool resetHideState();
 
     bool saveItemsChildren(const std::vector<WebDAVItem> &children);
 

--- a/src/api/webDAV.cpp
+++ b/src/api/webDAV.cpp
@@ -56,10 +56,10 @@ WebDAV::WebDAV()
 
     if (iv_access(CONFIG_PATH.c_str(), W_OK) == 0)
     {
-        _username = Util::accessConfig<string>(Action::IReadString,"username",{});
-        _password = Util::accessConfig<string>(Action::IReadSecret,"password",{});
-        _url = Util::accessConfig<string>(Action::IReadString, "url",{});
-        _ignoreCert = Util::accessConfig<int>(Action::IReadInt, "ignoreCert",{});
+        _username = Util::getConfig<string>("username");
+        _password = Util::getConfig<string>("password", "", true);
+        _url = Util::getConfig<string>("url");
+        _ignoreCert = Util::getConfig<int>("ignoreCert", -1);
     }
 }
 
@@ -89,17 +89,17 @@ std::vector<WebDAVItem> WebDAV::login(const string &Url, const string &Username,
         uuid = Username;
     }
     auto tempPath = NEXTCLOUD_ROOT_PATH + uuid + "/";
-    Util::accessConfig<string>( Action::IWriteString, "storageLocation", "/mnt/ext1/nextcloud");
+    Util::writeConfig<string>("storageLocation", "/mnt/ext1/nextcloud");
     std::vector<WebDAVItem> tempItems = getDataStructure(tempPath);
     if (!tempItems.empty())
     {
         if (iv_access(CONFIG_PATH.c_str(), W_OK) != 0)
             iv_buildpath(CONFIG_PATH.c_str());
-        Util::accessConfig<string>( Action::IWriteString, "url", _url);
-        Util::accessConfig<string>( Action::IWriteString, "username", _username);
-        Util::accessConfig<string>( Action::IWriteString, "UUID", uuid);
-        Util::accessConfig<string>( Action::IWriteSecret, "password", _password);
-        Util::accessConfig<int>( Action::IWriteInt, "ignoreCert", _ignoreCert);
+        Util::writeConfig<string>("url", _url);
+        Util::writeConfig<string>("username", _username);
+        Util::writeConfig<string>("UUID", uuid);
+        Util::writeConfig<string>("password", _password, true);
+        Util::writeConfig<int>("ignoreCert", _ignoreCert);
     }
     else
     {
@@ -114,7 +114,7 @@ void WebDAV::logout(bool deleteFiles)
 {
     if (deleteFiles)
     {
-        string filesPath = Util::accessConfig<string>(Action::IReadString, "storageLocation",{}) + "/" + Util::accessConfig<string>(Action::IReadString,"UUID",{}) + '/';
+        string filesPath = Util::getConfig<string>("storageLocation") + "/" + Util::getConfig<string>("UUID") + '/';
         if (fs::exists(filesPath)) 
             fs::remove_all(filesPath);
     }
@@ -189,7 +189,7 @@ vector<WebDAVItem> WebDAV::getDataStructure(const string &pathUrl)
             Util::decodeUrl(tempItem.localPath);
             if (tempItem.localPath.find(NEXTCLOUD_ROOT_PATH) != string::npos)
                 tempItem.localPath = tempItem.localPath.substr(NEXTCLOUD_ROOT_PATH.length());
-            tempItem.localPath = Util::accessConfig<string>(Action::IReadString, "storageLocation",{}) + "/" + tempItem.localPath;
+            tempItem.localPath = Util::getConfig<string>("storageLocation") + "/" + tempItem.localPath;
 
 
             if (tempItem.path.back() == '/')
@@ -311,7 +311,7 @@ string WebDAV::propfind(const string &pathUrl)
                             {
                             case 1:
                                 {
-                                    Util::accessConfig<string>(Action::IWriteString, "ex_relativeRootPath", "");
+                                    Util::writeConfig<string>("ex_relativeRootPath", "");
                                     return propfind(NEXTCLOUD_ROOT_PATH + Util::getConfig<std::string>("UUID", ""));
                                 }
                                 break;

--- a/src/api/webDAV.cpp
+++ b/src/api/webDAV.cpp
@@ -115,6 +115,7 @@ vector<WebDAVItem> WebDAV::getDataStructure(const string &pathUrl)
         size_t begin = xmlItem.find(beginItem);
         size_t end;
 
+        string prefix = NEXTCLOUD_ROOT_PATH + _username + "/";
         while (begin != std::string::npos)
         {
             end = xmlItem.find(endItem);
@@ -183,20 +184,11 @@ vector<WebDAVItem> WebDAV::getDataStructure(const string &pathUrl)
             tempItem.title = tempItem.title.substr(tempItem.title.find_last_of("/") + 1, tempItem.title.length());
             Util::decodeUrl(tempItem.title);
 
-            string folderPath = tempItem.path;
-            string prefix = NEXTCLOUD_ROOT_PATH + _username + "/";
-            if (tempItem.path.find(prefix) != string::npos) {
-                folderPath = tempItem.path.substr(prefix.length());
-                if (tempItem.type == Itemtype::IFILE && folderPath.length() >= tempItem.title.length()) {
-                    folderPath = folderPath.substr(0, folderPath.length() - tempItem.title.length());
-                }
-            }
-
-            if (tempItem.type == Itemtype::IFILE && ( !_fileHandler->excludeFolder(folderPath) && !_fileHandler->excludeFile(tempItem.title) )) 
-                tempItems.push_back(tempItem);
-            else if (tempItem.type == Itemtype::IFOLDER && !_fileHandler->excludeFolder(folderPath)) 
-                tempItems.push_back(tempItem);
-
+            string &pathDecoded = tempItem.path;
+            Util::decodeUrl(pathDecoded);
+            tempItem.hide = _fileHandler->getHideState(tempItem.type, prefix,(pathDecoded), tempItem.title);
+            
+            tempItems.push_back(tempItem);
             xmlItem = xmlItem.substr(end + endItem.length());
             begin = xmlItem.find(beginItem);
         }

--- a/src/api/webDAV.h
+++ b/src/api/webDAV.h
@@ -11,11 +11,14 @@
 #define WEBDAV
 
 #include "webDAVModel.h"
+#include "fileHandler.h"
 
 #include <string>
 #include <vector>
 
-const std::string NEXTCLOUD_ROOT_PATH = "/remote.php/dav/files/";
+#include <memory>
+
+const static std::string NEXTCLOUD_ROOT_PATH = "/remote.php/dav/files/";
 const std::string NEXTCLOUD_START_PATH = "/remote.php/";
 const std::string NEXTCLOUD_PATH = "/mnt/ext1/system/config/nextcloud";
 
@@ -27,6 +30,7 @@ class WebDAV
          *
          */
         WebDAV();
+        ~WebDAV();
 
         std::vector<WebDAVItem> login(const std::string &Url, const std::string &Username, const std::string &Pass, bool ignoreCert = false);
 
@@ -51,6 +55,8 @@ class WebDAV
         std::string _password;
         std::string _url;
         bool _ignoreCert;
+
+        std::shared_ptr<FileHandler> _fileHandler;
 
 };
 #endif

--- a/src/api/webDAV.h
+++ b/src/api/webDAV.h
@@ -38,6 +38,12 @@ class WebDAV
 
         std::vector<WebDAVItem> getDataStructure(const std::string &pathUrl);
 
+        /**
+         * Returns the root path of the nextcloud server 
+         * (e.g. /remote.php/dav/files/userName/startFolder/)
+         */
+        static std::string getRootPath(bool encode = false);
+
     /**
         * gets the dataStructure of the given URL and writes its WEBDAV items to the items vector
         *

--- a/src/api/webDAVModel.h
+++ b/src/api/webDAVModel.h
@@ -28,6 +28,13 @@ enum FileState
     IDOWNLOADED
 };
 
+enum HideState
+{
+    INOTDEFINED,
+    ISHOW,
+    IHIDE
+};
+
 struct WebDAVItem : Entry{
     std::string etag;
     std::string path;
@@ -38,6 +45,7 @@ struct WebDAVItem : Entry{
     tm lastEditDate = { 0 };
     std::string size;
     std::string fileType;
+    HideState hide;
 };
 
 #endif

--- a/src/handler/eventHandler.cpp
+++ b/src/handler/eventHandler.cpp
@@ -251,7 +251,8 @@ void EventHandler::mainMenuHandler(const int index)
             //Info
         case 106:
             {
-                Message(ICON_INFORMATION, "Info", "Version 1.02 \n For support please open a ticket at https://github.com/JuanJakobo/Pocketbook-Nextcloud-Client/issues", 1200);
+                string message;
+                Message(ICON_INFORMATION, "Info", message.append("Version ").append(PROGRAMVERSION).append("\nFor support please open a ticket at https://github.com/JuanJakobo/Pocketbook-Nextcloud-Client/issues").c_str(), 1200);
                 break;
             }
             //Exit
@@ -388,6 +389,7 @@ int EventHandler::pointerHandler(const int type, const int par1, const int par2)
                 Util::accessConfig<string>(Action::IWriteString, "ex_pattern",_excludeFileView->getRegex());
                 Util::accessConfig<string>(Action::IWriteString, "ex_folderPattern",_excludeFileView->getFolderRegex());
                 Util::accessConfig<int>(Action::IWriteInt, "ex_invertMatch", _excludeFileView->getInvertMatch());
+                _sqllite.resetHideState();
 
                 _excludeFileView.reset();
                 ShowHourglassForce();
@@ -655,6 +657,10 @@ void EventHandler::getLocalFileStructure(std::vector<WebDAVItem> &tempItems)
 
 void EventHandler::downloadFolder(vector<WebDAVItem> &items, int itemID)
 {
+    //Don't sync hidden files
+    if (items.at(itemID).hide == HideState::IHIDE)
+        return;
+    
     //BanSleep(2000);
     string path = items.at(itemID).path;
 

--- a/src/handler/eventHandler.cpp
+++ b/src/handler/eventHandler.cpp
@@ -42,11 +42,11 @@ EventHandler::EventHandler()
     if (iv_access(CONFIG_PATH.c_str(), W_OK) == 0)
     {
         //for backwards compatibilty
-        if (Util::accessConfig<string>(Action::IReadString, "storageLocation",{}).compare("error") == 0)
-                Util::accessConfig<string>(Action::IWriteString, "storageLocation", "/mnt/ext1/nextcloud");
+        if (Util::getConfig<string>("storageLocation", "error").compare("error") == 0)
+                Util::writeConfig<string>("storageLocation", "/mnt/ext1/nextcloud");
 
-        if (iv_access(Util::accessConfig<string>(Action::IReadString, "storageLocation",{}).c_str(), W_OK) != 0)
-            iv_mkdir(Util::accessConfig<string>(Action::IReadString, "storageLocation",{}).c_str(), 0777);
+        if (iv_access(Util::getConfig<string>("storageLocation").c_str(), W_OK) != 0)
+            iv_mkdir(Util::getConfig<string>("storageLocation").c_str(), 0777);
 
         std::vector<WebDAVItem> currentWebDAVItems;
         string path = WebDAV::getRootPath(true);
@@ -194,10 +194,10 @@ void EventHandler::mainMenuHandler(const int index)
                 switch (dialogResult)
                 {
                     case 1:
-                        Util::accessConfig<int>(Action::IWriteInt, "sortBy", 1);
+                        Util::writeConfig<int>("sortBy", 1);
                         break;
                     case 2:
-                        Util::accessConfig<int>(Action::IWriteInt, "sortBy", 2);
+                        Util::writeConfig<int>("sortBy", 2);
                         break;
                     default:
                         return;
@@ -233,7 +233,7 @@ void EventHandler::mainMenuHandler(const int index)
                 }
                 else
                 {
-                    Util::accessConfig<string>(Action::IWriteString, "storageLocation", _currentPath);
+                    Util::writeConfig<string>("storageLocation", _currentPath);
                     std::vector<WebDAVItem> currentWebDAVItems = _webDAV.getDataStructure(WebDAV::getRootPath(true));
                     if (currentWebDAVItems.empty())
                     {
@@ -385,11 +385,11 @@ int EventHandler::pointerHandler(const int type, const int par1, const int par2)
         else if (_excludeFileView != nullptr) {
             int click = _excludeFileView->excludeClicked(par1, par2);
             if (click == 3) {
-                Util::accessConfig<string>(Action::IWriteString, "ex_extensionList", _excludeFileView->getExtensionList());
-                Util::accessConfig<string>(Action::IWriteString, "ex_pattern",_excludeFileView->getRegex());
-                Util::accessConfig<string>(Action::IWriteString, "ex_folderPattern",_excludeFileView->getFolderRegex());
-                Util::accessConfig<string>(Action::IWriteString, "ex_relativeRootPath", _excludeFileView->getStartFolder());
-                Util::accessConfig<int>(Action::IWriteInt, "ex_invertMatch", _excludeFileView->getInvertMatch());
+                Util::writeConfig<string>("ex_extensionList", _excludeFileView->getExtensionList());
+                Util::writeConfig<string>("ex_pattern",_excludeFileView->getRegex());
+                Util::writeConfig<string>("ex_folderPattern",_excludeFileView->getFolderRegex());
+                Util::writeConfig<string>("ex_relativeRootPath", _excludeFileView->getStartFolder());
+                Util::writeConfig<int>("ex_invertMatch", _excludeFileView->getInvertMatch());
                 
                 _sqllite.resetHideState();
                 if (_excludeFileView->getStartFolder() != "") 
@@ -455,8 +455,8 @@ int EventHandler::pointerHandler(const int type, const int par1, const int par2)
                             break;
                         case 2:
                         default:
-                            if (iv_access(Util::accessConfig<string>(Action::IReadString, "storageLocation",{}).c_str(), W_OK) != 0)
-                                iv_mkdir(Util::accessConfig<string>(Action::IReadString, "storageLocation",{}).c_str(), 0777);
+                            if (iv_access(Util::getConfig<string>("storageLocation").c_str(), W_OK) != 0)
+                                iv_mkdir(Util::getConfig<string>("storageLocation").c_str(), 0777);
                             updateItems(currentWebDAVItems);
                             drawWebDAVItems(currentWebDAVItems);
                             break;

--- a/src/handler/eventHandler.cpp
+++ b/src/handler/eventHandler.cpp
@@ -432,7 +432,7 @@ int EventHandler::pointerHandler(const int type, const int par1, const int par2)
             {
                 ShowHourglassForce();
 
-                std::vector<WebDAVItem> currentWebDAVItems = _webDAV.login(_loginView->getURL(), _loginView->getUsername(), _loginView->getPassword(), _loginView->getIgnoreCert());;
+                std::vector<WebDAVItem> currentWebDAVItems = _webDAV.login(_loginView->getURL(), _loginView->getUsername(), _loginView->getPassword(), _loginView->getIgnoreCert());
                 if (currentWebDAVItems.empty())
                 {
                     Message(ICON_ERROR, "Error", "Login failed.", 1000);

--- a/src/handler/eventHandler.h
+++ b/src/handler/eventHandler.h
@@ -15,7 +15,10 @@
 #include "webDAVView.h"
 #include "loginView.h"
 #include "fileView.h"
+#include "excludeFileView.h"
 #include "sqliteConnector.h"
+#include "log.h"
+#include "fileHandler.h"
 
 #include <memory>
 
@@ -40,12 +43,16 @@ public:
         */
     int eventDistributor(const int type, const int par1, const int par2);
 
+
 private:
     static std::unique_ptr<EventHandler> _eventHandlerStatic;
     std::unique_ptr<WebDAVView> _webDAVView;
     std::unique_ptr<LoginView> _loginView;
     std::unique_ptr<FileView> _fileView;
+    std::unique_ptr<ExcludeFileView> _excludeFileView;
     std::unique_ptr<MainMenu> _menu;
+
+    std::shared_ptr<FileHandler> _fileHandler;
 
     ContextMenu _contextMenu = ContextMenu();
     WebDAV _webDAV = WebDAV();

--- a/src/handler/fileHandler.cpp
+++ b/src/handler/fileHandler.cpp
@@ -1,0 +1,138 @@
+//------------------------------------------------------------------
+// fileHandler.cpp
+//
+// Author:           RPJoshL
+// Date:             03.10.2022
+//
+//-------------------------------------------------------------------
+
+#include "fileHandler.h"
+#include "log.h"
+#include "util.h"
+
+#include <sstream>
+#include <regex>
+#include <algorithm>
+#include <string>
+
+using std::string;
+using std::find;
+using std::regex;
+
+std::vector<FileHandler*> FileHandler::_instances;
+FileHandler::FileHandler()
+{
+    _instances.push_back(this);
+
+    parseConfig(
+        Util::getConfig<string>("ex_pattern", ""),
+        Util::getConfig<string>("ex_folderPattern", ""),
+        Util::getConfig<string>("ex_extensionList", ""),
+        Util::getConfig<int>("ex_invertMatch", 0)
+    );
+
+}
+
+void FileHandler::parseConfig(string regex, string folderRegex, string extensions, int invertMatch) {
+    _extensions.clear();
+    // split the comma seperated string
+    if (!extensions.empty()) {
+        string line;
+
+        std::stringstream ss(extensions);
+        while(getline(ss, line, ',')) {
+            _extensions.push_back(line);
+        }
+    }
+
+    // parse the regex only onces
+    if (!regex.empty()) {
+        try {
+            _regex = std::regex(regex);
+            _useRegex = true;
+        } catch(std::regex_error err) {
+            Log::writeErrorLog("Unable to parse regex '" + regex + "' for file: " + err.what());
+        }
+    } else {
+        _useRegex = false;
+    }
+
+    if (!folderRegex.empty()) {
+        try {
+            _folderRegex = std::regex(folderRegex);
+            _useFolderRegex = true;
+        } catch(std::regex_error err) {
+            Log::writeErrorLog("Unable to parse regex '" + folderRegex + "' for folder: " + err.what());
+        }
+    } else {
+        _useFolderRegex = false;
+    }
+
+    _invertMatch = invertMatch;
+}
+
+FileHandler::~FileHandler() 
+{
+    _instances.erase(std::remove(_instances.begin(), _instances.end(), this), _instances.end());
+}
+
+bool FileHandler::excludeFile(std::string filename) {
+
+    // check for file extensions
+    if (!_extensions.empty()) {
+        int indexOfDot = filename.find_last_of(".");
+        if (indexOfDot != std::string::npos && filename.length() > indexOfDot + 1) {
+            string extension = filename.substr(filename.find_last_of(".") + 1);
+            if(std::find(_extensions.begin(),_extensions.end(), extension) != _extensions.end()) {
+                return !_invertMatch;
+            }
+        }
+    }
+
+    if (_useRegex) {
+        try {
+            bool t = std::regex_match(filename, _regex) != _invertMatch;
+            string ta = t ? "true" : "false";
+            return t;
+        } catch (std::regex_error err) {
+            string errM = err.what();
+            Log::writeErrorLog("Unable to parse regex for file:'" + errM);
+        }
+    }
+
+    return _invertMatch;
+}
+
+bool FileHandler::excludeFolder(std::string folderName) {
+    folderName = "/" + folderName;
+
+    // always display root folder because that can't be matched
+    if (folderName == "/" || folderName == "//") {
+        return false;
+    }
+
+    if (_useFolderRegex) {
+        try {
+            bool t = std::regex_match(folderName, _folderRegex) != _invertMatch;
+            return t;
+        } catch (std::regex_error err) {
+            string errM = err.what();
+            Log::writeErrorLog("Unable to parse regex for folder:'" + errM);
+        }
+    }
+
+    return _invertMatch;
+}
+
+void FileHandler::update(string regex, string folderRegex, string extensions, int invertMatch) {
+    for (FileHandler *handler : _instances) {
+        handler->parseConfig(regex, folderRegex, extensions, invertMatch);
+    }
+}
+
+string FileHandler::getStorageLocation() {
+    return Util::accessConfig<string>(Action::IReadString, "storageLocation",{}) + getStorageUsername() + "/";
+}
+string FileHandler::getStorageUsername() {
+    return Util::accessConfig<string>(Action::IReadString, "username",{});
+}

--- a/src/handler/fileHandler.cpp
+++ b/src/handler/fileHandler.cpp
@@ -9,6 +9,7 @@
 #include "fileHandler.h"
 #include "log.h"
 #include "util.h"
+#include "webDAVModel.h"
 
 #include <sstream>
 #include <regex>
@@ -123,6 +124,33 @@ bool FileHandler::excludeFolder(std::string folderName) {
 
     return _invertMatch;
 }
+
+HideState FileHandler::getHideState(Itemtype itemType, std::string prefix, std::string path, std::string title = "") {
+
+    string folderPath = path;
+    if (path.find(prefix) != string::npos) {
+         folderPath = path.substr(prefix.length());
+        if (itemType == Itemtype::IFILE && folderPath.length() >= title.length()) {
+            folderPath = folderPath.substr(0, folderPath.length() - title.length());
+        }
+    }
+    folderPath = "/" + folderPath;
+
+    if (itemType == Itemtype::IFILE) {
+        if (!excludeFolder(folderPath) && !excludeFile(title)) {
+            return HideState::ISHOW;
+        } else {
+            return HideState::IHIDE;
+        }
+    } else {
+        if (!excludeFolder(folderPath)) {
+            return HideState::ISHOW;
+        } else {
+            return HideState::IHIDE;
+        }
+    }
+}
+
 
 void FileHandler::update(string regex, string folderRegex, string extensions, int invertMatch) {
     for (FileHandler *handler : _instances) {

--- a/src/handler/fileHandler.cpp
+++ b/src/handler/fileHandler.cpp
@@ -93,7 +93,6 @@ bool FileHandler::excludeFile(std::string filename) {
     if (_useRegex) {
         try {
             bool t = std::regex_match(filename, _regex) != _invertMatch;
-            string ta = t ? "true" : "false";
             return t;
         } catch (std::regex_error err) {
             string errM = err.what();

--- a/src/handler/fileHandler.cpp
+++ b/src/handler/fileHandler.cpp
@@ -158,8 +158,8 @@ void FileHandler::update(string regex, string folderRegex, string extensions, in
 }
 
 string FileHandler::getStorageLocation() {
-    return Util::accessConfig<string>(Action::IReadString, "storageLocation",{}) + getStorageUsername() + "/";
+    return Util::getConfig<string>("storageLocation") + getStorageUsername() + "/";
 }
 string FileHandler::getStorageUsername() {
-    return Util::accessConfig<string>(Action::IReadString, "username",{});
+    return Util::getConfig<string>("username");
 }

--- a/src/handler/fileHandler.h
+++ b/src/handler/fileHandler.h
@@ -9,6 +9,8 @@
 #ifndef FILEHANDLER
 #define FILEHANDLER
 
+#include "webDAVModel.h"
+
 #include <regex>
 #include <string>
 #include <vector>
@@ -22,6 +24,7 @@ class FileHandler
         ~FileHandler();
         bool excludeFile(std::string filename);
         bool excludeFolder(std::string foldername);
+        HideState getHideState(Itemtype itemType, std::string prefixToStripe, std::string path, std::string title);
 
         std::string getStorageLocation();
         std::string getStorageUsername();

--- a/src/handler/fileHandler.h
+++ b/src/handler/fileHandler.h
@@ -1,0 +1,43 @@
+//------------------------------------------------------------------
+// fileHandler.h
+//
+// Author:           RPJoshL
+// Date:             03.10.2022
+//
+//-------------------------------------------------------------------
+
+#ifndef FILEHANDLER
+#define FILEHANDLER
+
+#include <regex>
+#include <string>
+#include <vector>
+
+#include <memory>
+
+class FileHandler
+{
+    public:
+        FileHandler();
+        ~FileHandler();
+        bool excludeFile(std::string filename);
+        bool excludeFolder(std::string foldername);
+
+        std::string getStorageLocation();
+        std::string getStorageUsername();
+        static void update(std::string regex, std::string folderRegex, std::string extensions, int invertMatch);
+
+    private:
+        std::regex              _regex;
+        std::regex              _folderRegex;
+        // can't use pointers with regex... Why? -> unable to null check
+        bool                    _useRegex = false;
+        bool                    _useFolderRegex = false;
+        std::vector<std::string> _extensions;
+        bool                     _invertMatch;
+
+        void parseConfig(std::string regex, std::string folderRegex, std::string extensions, int invertMatch);
+        static std::vector<FileHandler *> _instances;
+
+};
+#endif

--- a/src/handler/mainMenu.cpp
+++ b/src/handler/mainMenu.cpp
@@ -42,6 +42,7 @@ MainMenu::~MainMenu()
     free(_menu);
     free(_logout);
     free(_sortBy);
+    free(_excludeFiles);
     free(_info);
     free(_exit);
     free(_chooseFolder);
@@ -61,14 +62,15 @@ int MainMenu::createMenu(bool filePicker, bool loggedIn, iv_menuhandler handler)
             //show logged in
             {loggedIn ? (short)ITEM_ACTIVE : (short)ITEM_HIDDEN, 101, _syncFolder, NULL},
             {loggedIn ? (short)ITEM_ACTIVE : (short)ITEM_HIDDEN, 103, _sortBy, NULL},
+            {loggedIn ? (short)ITEM_ACTIVE : (short)ITEM_HIDDEN, 104, _excludeFiles, NULL},
             //show if filePicker is shown
-            {filePicker ? (short)ITEM_ACTIVE : (short)ITEM_HIDDEN, 104, _chooseFolder, NULL},
+            {filePicker ? (short)ITEM_ACTIVE : (short)ITEM_HIDDEN, 105, _chooseFolder, NULL},
             //show always
-            {ITEM_ACTIVE, 105, _info, NULL},
+            {ITEM_ACTIVE, 106, _info, NULL},
             //show logged in
             {loggedIn ? (short)ITEM_ACTIVE : (short)ITEM_HIDDEN, 102, _logout, NULL},
             //show always
-            {ITEM_ACTIVE, 106, _exit, NULL},
+            {ITEM_ACTIVE, 107, _exit, NULL},
             {0, 0, NULL, NULL}};
 
     OpenMenu(mainMenu, 0, _panelMenuBeginX, _panelMenuBeginY, handler);

--- a/src/handler/mainMenu.h
+++ b/src/handler/mainMenu.h
@@ -55,7 +55,7 @@ private:
     char *_logout = strdup("Logout");
     char *_chooseFolder = strdup("Create here");
     char *_sortBy = strdup("Order items by");
-    char *_excludeFiles = strdup("Exclude and hide files");
+    char *_excludeFiles = strdup("Exclude and hide items");
     char *_info = strdup("Info");
     char *_exit = strdup("Close App");
 

--- a/src/handler/mainMenu.h
+++ b/src/handler/mainMenu.h
@@ -55,6 +55,7 @@ private:
     char *_logout = strdup("Logout");
     char *_chooseFolder = strdup("Create here");
     char *_sortBy = strdup("Order items by");
+    char *_excludeFiles = strdup("Exclude and hide files");
     char *_info = strdup("Info");
     char *_exit = strdup("Close App");
 

--- a/src/ui/excludeFileView/excludeFileView.cpp
+++ b/src/ui/excludeFileView/excludeFileView.cpp
@@ -1,0 +1,200 @@
+//------------------------------------------------------------------
+// excludeFileView.cpp
+//
+// Author:           RPJoshL
+// Date:             03.10.2022
+//
+//-------------------------------------------------------------------
+
+#include "excludeFileView.h"
+#include "log.h"
+#include "util.h"
+
+#include <regex>
+
+using std::string;
+
+std::shared_ptr<ExcludeFileView> ExcludeFileView::_excludeFileViewStatic;
+ExcludeFileView::ExcludeFileView(const irect &contentRect): _contentRect(contentRect)
+{
+    _excludeFileViewStatic.reset(this);
+
+    _extensionList = Util::getConfig<string>("ex_extensionList", "");
+    _regex = Util::getConfig<string>("ex_pattern", "");
+    _folderRegex = Util::getConfig<string>("ex_folderPattern", "");
+    _invertMatch =  Util::getConfig<int>("ex_invertMatch",0);
+
+    int contentHeight = contentRect.h / 2;
+    int contentWidth = _contentRect.w * 0.9;
+    int checkBoxWidth = _contentRect.w * 0.1;
+
+    int beginY = 0.4 * contentHeight;
+    int beginX = (_contentRect.w - contentWidth) / 2;
+
+    int contents = contentHeight / 7;
+
+    _fontHeight = contents / 2;
+
+    _font = OpenFont("LiberationMono", _fontHeight, FONT_STD);
+    SetFont(_font, BLACK);
+    FillAreaRect(&_contentRect, WHITE);
+
+    _extensionListButton = iRect(beginX, beginY, contentWidth, contents, ALIGN_CENTER);
+    DrawTextRect(_extensionListButton.x, _extensionListButton.y - _fontHeight - _fontHeight/2, _extensionListButton.w, _extensionListButton.h, "Extensions:", ALIGN_LEFT);
+    DrawString(_extensionListButton.x, _extensionListButton.y, _extensionList.c_str());
+    DrawRect(_extensionListButton.x - 1, _extensionListButton.y - 1, _extensionListButton.w + 2, _extensionListButton.h + 2, BLACK);
+
+    _regexButton = iRect(beginX, beginY + 2 * contents, contentWidth, contents, ALIGN_CENTER);
+    DrawTextRect(_regexButton.x, _regexButton.y - _fontHeight - _fontHeight/3, _regexButton.w, _regexButton.h, "File-Regex:", ALIGN_LEFT);
+    DrawString(_regexButton.x, _regexButton.y, _regex.c_str());
+    DrawRect(_regexButton.x - 1, _regexButton.y - 1, _regexButton.w + 2, _regexButton.h + 2, BLACK);
+
+    _folderRegexButton = iRect(beginX, beginY + 4 * contents, contentWidth, contents, ALIGN_CENTER);
+    DrawTextRect(_folderRegexButton.x, _folderRegexButton.y - _fontHeight - _fontHeight/3, _folderRegexButton.w, _folderRegexButton.h, "Folder-Regex:", ALIGN_LEFT);
+    DrawString(_folderRegexButton.x, _folderRegexButton.y, _folderRegex.c_str());
+    DrawRect(_folderRegexButton.x - 1, _folderRegexButton.y - 1, _folderRegexButton.w + 2, _folderRegexButton.h + 2, BLACK);
+
+    _invertMatchButton = iRect(_contentRect.w - 2 * checkBoxWidth, beginY + 6 * contents, checkBoxWidth, contents, ALIGN_CENTER);
+    DrawTextRect(beginX, _invertMatchButton.y, contentWidth, _invertMatchButton.h, "Only include matching:", ALIGN_LEFT);
+    DrawRect(_invertMatchButton.x - 1, _invertMatchButton.y - 1, _invertMatchButton.w + 2, _invertMatchButton.h + 2, BLACK);
+    if (_invertMatch) {
+        FillArea(_invertMatchButton.x - 1, _invertMatchButton.y - 1, _invertMatchButton.w + 2, _invertMatchButton.h + 2, BLACK);
+    }
+
+    _saveButton = iRect(beginX, beginY + 8 * contents, contentWidth / 2 - 20, contents, ALIGN_CENTER);
+    FillAreaRect(&_saveButton, BLACK);
+    SetFont(_font, WHITE);
+    DrawTextRect2(&_saveButton, "Save");
+    PartialUpdate(_contentRect.x, _contentRect.y, _contentRect.w, _contentRect.h);
+
+    _cancelButton = iRect(beginX + contentWidth / 2, beginY + 8 * contents, contentWidth / 2 - 20, contents, ALIGN_CENTER);
+    FillAreaRect(&_cancelButton, BLACK);
+    SetFont(_font, WHITE);
+    DrawTextRect2(&_cancelButton, "Cancel");
+    PartialUpdate(_contentRect.x, _contentRect.y, _contentRect.w, _contentRect.h);
+}
+
+ExcludeFileView::~ExcludeFileView() 
+{
+    CloseFont(_font);
+}
+
+int ExcludeFileView::excludeClicked(int x, int y)
+{
+    _temp = "";
+
+    if (IsInRect(x, y, &_extensionListButton))
+    {
+        _target = ExcludeFileKeyboardTarget::IEXTENSIONS;
+        if (!_extensionList.empty())
+            _temp = _extensionList;
+        _temp.resize(EXCLUDE_FILE_KEYBOARD_STRING_LENGHT);
+        OpenKeyboard("docx,pdf,sdr", &_temp[0], EXCLUDE_FILE_KEYBOARD_STRING_LENGHT - 1, KBD_NORMAL, &keyboardHandlerStatic);
+        return 1;
+    }
+    else if (IsInRect(x, y, &_regexButton))
+    {
+        _target = ExcludeFileKeyboardTarget::IREGEX;
+        if (!_regex.empty())
+            _temp = _regex;
+        _temp.resize(EXCLUDE_FILE_KEYBOARD_STRING_LENGHT);
+        OpenKeyboard("Pre.*Post\\.pdf", &_temp[0], EXCLUDE_FILE_KEYBOARD_STRING_LENGHT, KBD_NORMAL, &keyboardHandlerStatic);
+        return 1;
+    }
+    else if (IsInRect(x, y, &_folderRegexButton))
+    {
+        _target = ExcludeFileKeyboardTarget::IFOLDERREGEX;
+        if (!_folderRegex.empty())
+            _temp = _folderRegex;
+        _temp.resize(EXCLUDE_FILE_KEYBOARD_STRING_LENGHT);
+        OpenKeyboard("/root/.*/test/", &_temp[0], EXCLUDE_FILE_KEYBOARD_STRING_LENGHT, KBD_NORMAL, &keyboardHandlerStatic);
+        return 1;
+    }
+    else if (IsInRect(x, y, &_invertMatchButton))
+    {
+        _invertMatch = !_invertMatch;
+        FillAreaRect(&_invertMatchButton, WHITE);
+        if(_invertMatch)
+            FillArea(_invertMatchButton.x - 1, _invertMatchButton.y - 1, _invertMatchButton.w + 2, _invertMatchButton.h + 2, BLACK);
+        else
+            DrawRect(_invertMatchButton.x - 1, _invertMatchButton.y - 1, _invertMatchButton.w + 2, _invertMatchButton.h + 2, BLACK);
+
+        PartialUpdate(_invertMatchButton.x, _invertMatchButton.y, _invertMatchButton.w, _invertMatchButton.h);
+
+        return 1;
+    }
+    else if (IsInRect(x, y, &_saveButton)) 
+    {
+        if (!_regex.empty()) {
+            try {
+                std::regex regP = std::regex(_regex);
+            } catch(std::regex_error err) {
+                Log::writeErrorLog("Unable to parse regex '" + _regex + "': " + err.what());
+                Message(ICON_ERROR, "Error", "Unable to parse the regex for the files.", 1200);
+                return 1;
+            } catch(...) {
+                Message(ICON_ERROR, "Error", "Unknown error occured while parsing the regex for the files.", 1200);
+                return 1;
+            }
+        }
+
+        if (!_folderRegex.empty()) {
+            try {
+                std::regex regP = std::regex(_folderRegex);
+            } catch(std::regex_error err) {
+                Log::writeErrorLog("Unable to parse regex for folder '" + _folderRegex + "': " + err.what());
+                Message(ICON_ERROR, "Error", "Unable to parse the regex for the folders.", 1200);
+                return 1;
+            } catch(...) {
+                Message(ICON_ERROR, "Error", "Unknown error occured while parsing the regex for the folders.", 1200);
+                return 1;
+            }
+        }
+
+        FileHandler::update(_regex, _folderRegex, _extensionList, _invertMatch);
+
+        return 3;
+    }
+    else if (IsInRect(x, y, &_cancelButton))
+    {
+        return -1;
+    }
+
+    return 0;
+}
+
+void ExcludeFileView::keyboardHandlerStatic(char *text)
+{
+    if (_excludeFileViewStatic != nullptr) {
+        _excludeFileViewStatic->keyboardHandler(text);
+    }
+}
+
+void ExcludeFileView::keyboardHandler(char *text)
+{
+    if (!text)
+        return;
+
+    string s(text);
+    if (s.empty())
+        return;
+
+    if (_target == ExcludeFileKeyboardTarget::IEXTENSIONS)
+    {
+        _extensionList = s.c_str();
+        FillAreaRect(&_extensionListButton, WHITE);
+        DrawTextRect2(&_extensionListButton, s.c_str());
+    }
+    else if (_target == ExcludeFileKeyboardTarget::IREGEX)
+    {
+        _regex = s.c_str();
+        FillAreaRect(&_regexButton, WHITE);
+        DrawTextRect2(&_regexButton, s.c_str());
+    }
+    else if (_target == ExcludeFileKeyboardTarget::IFOLDERREGEX)
+    {
+        _folderRegex = s.c_str();
+        FillAreaRect(&_folderRegexButton, WHITE);
+        DrawTextRect2(&_folderRegexButton, s.c_str());
+    }
+}

--- a/src/ui/excludeFileView/excludeFileView.cpp
+++ b/src/ui/excludeFileView/excludeFileView.cpp
@@ -22,6 +22,7 @@ ExcludeFileView::ExcludeFileView(const irect &contentRect): _contentRect(content
     _extensionList = Util::getConfig<string>("ex_extensionList", "");
     _regex = Util::getConfig<string>("ex_pattern", "");
     _folderRegex = Util::getConfig<string>("ex_folderPattern", "");
+    _startFolder = Util::getConfig<string>("ex_relativeRootPath", "");
     _invertMatch =  Util::getConfig<int>("ex_invertMatch",0);
 
     int contentHeight = contentRect.h / 2;
@@ -54,20 +55,25 @@ ExcludeFileView::ExcludeFileView(const irect &contentRect): _contentRect(content
     DrawString(_folderRegexButton.x, _folderRegexButton.y, _folderRegex.c_str());
     DrawRect(_folderRegexButton.x - 1, _folderRegexButton.y - 1, _folderRegexButton.w + 2, _folderRegexButton.h + 2, BLACK);
 
-    _invertMatchButton = iRect(_contentRect.w - 2 * checkBoxWidth, beginY + 6 * contents, checkBoxWidth, contents, ALIGN_CENTER);
+    _startFolderButton = iRect(beginX, beginY + 6 * contents, contentWidth, contents, ALIGN_CENTER);
+    DrawTextRect(_startFolderButton.x, _startFolderButton.y - _fontHeight - _fontHeight/3, _startFolderButton.w, _startFolderButton.h, "Start folder:", ALIGN_LEFT);
+    DrawString(_startFolderButton.x, _startFolderButton.y, _startFolder.c_str());
+    DrawRect(_startFolderButton.x - 1, _startFolderButton.y - 1, _startFolderButton.w + 2, _startFolderButton.h + 2, BLACK);
+
+    _invertMatchButton = iRect(_contentRect.w - 2 * checkBoxWidth, beginY + 8 * contents, checkBoxWidth, contents, ALIGN_CENTER);
     DrawTextRect(beginX, _invertMatchButton.y, contentWidth, _invertMatchButton.h, "Only include matching:", ALIGN_LEFT);
     DrawRect(_invertMatchButton.x - 1, _invertMatchButton.y - 1, _invertMatchButton.w + 2, _invertMatchButton.h + 2, BLACK);
     if (_invertMatch) {
         FillArea(_invertMatchButton.x - 1, _invertMatchButton.y - 1, _invertMatchButton.w + 2, _invertMatchButton.h + 2, BLACK);
     }
 
-    _saveButton = iRect(beginX, beginY + 8 * contents, contentWidth / 2 - 20, contents, ALIGN_CENTER);
+    _saveButton = iRect(beginX, beginY + 10 * contents, contentWidth / 2 - 20, contents, ALIGN_CENTER);
     FillAreaRect(&_saveButton, BLACK);
     SetFont(_font, WHITE);
     DrawTextRect2(&_saveButton, "Save");
     PartialUpdate(_contentRect.x, _contentRect.y, _contentRect.w, _contentRect.h);
 
-    _cancelButton = iRect(beginX + contentWidth / 2, beginY + 8 * contents, contentWidth / 2 - 20, contents, ALIGN_CENTER);
+    _cancelButton = iRect(beginX + contentWidth / 2, beginY + 10 * contents, contentWidth / 2 - 20, contents, ALIGN_CENTER);
     FillAreaRect(&_cancelButton, BLACK);
     SetFont(_font, WHITE);
     DrawTextRect2(&_cancelButton, "Cancel");
@@ -109,6 +115,15 @@ int ExcludeFileView::excludeClicked(int x, int y)
             _temp = _folderRegex;
         _temp.resize(EXCLUDE_FILE_KEYBOARD_STRING_LENGHT);
         OpenKeyboard("/root/.*/test/", &_temp[0], EXCLUDE_FILE_KEYBOARD_STRING_LENGHT, KBD_NORMAL, &keyboardHandlerStatic);
+        return 1;
+    }
+    else if (IsInRect(x, y, &_startFolderButton))
+    {
+        _target = ExcludeFileKeyboardTarget::ISTARTFOLDER;
+        if (!_startFolder.empty())
+            _temp = _startFolder;
+        _temp.resize(EXCLUDE_FILE_KEYBOARD_STRING_LENGHT);
+        OpenKeyboard("/MyBooks/", &_temp[0], EXCLUDE_FILE_KEYBOARD_STRING_LENGHT, KBD_NORMAL, &keyboardHandlerStatic);
         return 1;
     }
     else if (IsInRect(x, y, &_invertMatchButton))
@@ -197,5 +212,19 @@ void ExcludeFileView::keyboardHandler(char *text)
         _folderRegex = s.c_str();
         FillAreaRect(&_folderRegexButton, WHITE);
         DrawTextRect2(&_folderRegexButton, s.c_str());
+    }
+    else if (_target == ExcludeFileKeyboardTarget::ISTARTFOLDER)
+    {
+        _startFolder = s.c_str();
+        if (_startFolder.length() > 1 && _startFolder != "/") {
+            if (_startFolder.substr(0, 1) != "/") {
+                _startFolder = "/" + _startFolder;
+            }
+            if (_startFolder.substr(_startFolder.length() - 1) != "/") {
+                _startFolder = _startFolder + "/";
+            }
+        }
+        FillAreaRect(&_startFolderButton, WHITE);
+        DrawTextRect2(&_startFolderButton, _startFolder.c_str());
     }
 }

--- a/src/ui/excludeFileView/excludeFileView.cpp
+++ b/src/ui/excludeFileView/excludeFileView.cpp
@@ -14,10 +14,10 @@
 
 using std::string;
 
-std::shared_ptr<ExcludeFileView> ExcludeFileView::_excludeFileViewStatic;
+ExcludeFileView* ExcludeFileView::_excludeFileViewStatic;
 ExcludeFileView::ExcludeFileView(const irect &contentRect): _contentRect(contentRect)
 {
-    _excludeFileViewStatic.reset(this);
+    _excludeFileViewStatic = this;
 
     _extensionList = Util::getConfig<string>("ex_extensionList", "");
     _regex = Util::getConfig<string>("ex_pattern", "");
@@ -77,6 +77,7 @@ ExcludeFileView::ExcludeFileView(const irect &contentRect): _contentRect(content
 ExcludeFileView::~ExcludeFileView() 
 {
     CloseFont(_font);
+    // Pointer cannot be freeded... It would crash when optining the window >~ 2 times (as well as an shared_ptr)
 }
 
 int ExcludeFileView::excludeClicked(int x, int y)
@@ -176,8 +177,8 @@ void ExcludeFileView::keyboardHandler(char *text)
         return;
 
     string s(text);
-    if (s.empty())
-        return;
+    //if (s.empty())
+    //    return;
 
     if (_target == ExcludeFileKeyboardTarget::IEXTENSIONS)
     {

--- a/src/ui/excludeFileView/excludeFileView.h
+++ b/src/ui/excludeFileView/excludeFileView.h
@@ -54,7 +54,7 @@ public:
     int getInvertMatch() { return _invertMatch; };
 
 private:
-    static std::shared_ptr<ExcludeFileView> _excludeFileViewStatic;
+    static ExcludeFileView *_excludeFileViewStatic;
     int         _fontHeight;
     ifont       *_font;
     const irect _contentRect;

--- a/src/ui/excludeFileView/excludeFileView.h
+++ b/src/ui/excludeFileView/excludeFileView.h
@@ -1,0 +1,88 @@
+//------------------------------------------------------------------
+// excludeFileView.h
+//
+// Author:           RPJoshL
+// Date:             03.10.2022
+//
+//-------------------------------------------------------------------
+
+#include <string>
+
+#ifndef EXCLUDEFILEVIEW
+#define EXCLUDEFILEVIEW
+
+using std::string;
+
+#include "inkview.h"
+
+#include <string>
+#include <memory>
+
+enum class ExcludeFileKeyboardTarget
+{
+    IEXTENSIONS,
+    IREGEX,
+    IFOLDERREGEX
+};
+
+const int EXCLUDE_FILE_KEYBOARD_STRING_LENGHT = 90;
+
+class ExcludeFileView
+{
+public:
+    /**
+        * Draws the excludeFileView including an textfield with Extension list and regex, checkbox for inverting the "excluding" and the 
+        * save and cancel button inside the contentRect
+        *
+        * @param contentRect area where the excludeFileView shall be drawn
+        */
+    ExcludeFileView(const irect &contentRect);
+    ~ExcludeFileView();
+
+    /**
+        * Checks which part of the view is shown and reacts accordingly
+        *
+        * @param x x-coordinate
+        * @param y y-coordinate
+        * @return int if event has been handled. Returns 2 if save has been clicked and all items are set, or -1 when cancel was fired
+        */
+    int excludeClicked(int x, int y);
+
+    std::string getExtensionList() { return _extensionList; };
+    std::string getRegex() { return _regex; };
+    std::string getFolderRegex() { return _folderRegex; };
+    int getInvertMatch() { return _invertMatch; };
+
+private:
+    static std::shared_ptr<ExcludeFileView> _excludeFileViewStatic;
+    int         _fontHeight;
+    ifont       *_font;
+    const irect _contentRect;
+    irect       _saveButton;
+    irect       _cancelButton;
+    irect       _extensionListButton;
+    irect       _regexButton;
+    irect       _invertMatchButton;
+    irect       _folderRegexButton;
+    ExcludeFileKeyboardTarget _target;
+    std::string _extensionList;
+    std::string _regex;
+    std::string _folderRegex;
+    bool        _invertMatch = false;
+    std::string _temp;
+
+    /**
+        * Functions needed to call C function, handles the keyboard
+        *
+        * @param  text text that has been typed in by the user
+        */
+    static void keyboardHandlerStatic(char *text);
+
+    /**
+        * Called by the static method and saves and writes the input from the user to the screen
+        *
+        * @param text text that has been typed in by the user
+        */
+    void keyboardHandler(char *text);
+};
+#endif

--- a/src/ui/excludeFileView/excludeFileView.h
+++ b/src/ui/excludeFileView/excludeFileView.h
@@ -22,7 +22,8 @@ enum class ExcludeFileKeyboardTarget
 {
     IEXTENSIONS,
     IREGEX,
-    IFOLDERREGEX
+    IFOLDERREGEX,
+    ISTARTFOLDER,
 };
 
 const int EXCLUDE_FILE_KEYBOARD_STRING_LENGHT = 90;
@@ -51,6 +52,7 @@ public:
     std::string getExtensionList() { return _extensionList; };
     std::string getRegex() { return _regex; };
     std::string getFolderRegex() { return _folderRegex; };
+    std::string getStartFolder() { return _startFolder; };
     int getInvertMatch() { return _invertMatch; };
 
 private:
@@ -64,10 +66,12 @@ private:
     irect       _regexButton;
     irect       _invertMatchButton;
     irect       _folderRegexButton;
+    irect       _startFolderButton;
     ExcludeFileKeyboardTarget _target;
     std::string _extensionList;
     std::string _regex;
     std::string _folderRegex;
+    std::string _startFolder;
     bool        _invertMatch = false;
     std::string _temp;
 

--- a/src/ui/webDAVView/webDAVView.cpp
+++ b/src/ui/webDAVView/webDAVView.cpp
@@ -17,8 +17,14 @@
 
 using std::vector;
 
-WebDAVView::WebDAVView(const irect &contentRect, vector<WebDAVItem> &items, int page) : ListView(contentRect, page)
+WebDAVView::WebDAVView(const irect &contentRect, vector<WebDAVItem> &itemsUnfiltered, int page) : ListView(contentRect, page)
 {
+    vector<WebDAVItem> items;
+    std::copy_if (itemsUnfiltered.begin(), itemsUnfiltered.end(), std::back_inserter(items), [](WebDAVItem i)
+    {
+        return i.hide != HideState::IHIDE;
+    });
+
     auto pageHeight = 0;
     auto contentHeight = _contentRect.h - _footerHeight;
     auto entrycount = items.size();

--- a/src/ui/webDAVView/webDAVView.cpp
+++ b/src/ui/webDAVView/webDAVView.cpp
@@ -55,7 +55,7 @@ WebDAVView::WebDAVView(const irect &contentRect, vector<WebDAVItem> &itemsUnfilt
 
     sort(begin, items.end(), []( WebDAVItem &w1, WebDAVItem &w2) -> bool
     {
-        if(Util::accessConfig<int>(Action::IReadInt, "sortBy", 0) == 2)
+        if(Util::getConfig<int>("sortBy", -1) == 2)
         {
             //sort by lastmodified
             time_t t1 = mktime(&w1.lastEditDate);

--- a/src/ui/webDAVView/webDAVView.cpp
+++ b/src/ui/webDAVView/webDAVView.cpp
@@ -41,7 +41,9 @@ WebDAVView::WebDAVView(const irect &contentRect, vector<WebDAVItem> &itemsUnfilt
 
     std::vector<WebDAVItem>::iterator begin;
 
-    if (items.at(0).path.compare(NEXTCLOUD_ROOT_PATH) == 0)
+    string rootPath = WebDAV::getRootPath(false);
+    string parentRootPath =  rootPath.substr(0, rootPath.substr(0, rootPath.length() - 1).find_last_of("/") + 1);
+    if (items.at(0).path.compare(parentRootPath) == 0)
     {
         items.erase(items.begin());
         begin = items.begin();

--- a/src/util/util.cpp
+++ b/src/util/util.cpp
@@ -100,6 +100,18 @@ void Util::decodeUrl(string &text)
     curl_easy_cleanup(curl);
 }
 
+void Util::encodeUrl(string &text) 
+{
+    char *buffer;
+    CURL *curl = curl_easy_init();
+
+    buffer = curl_easy_escape(curl, text.c_str(), 0);
+    text = buffer;
+
+    curl_free(buffer);
+    curl_easy_cleanup(curl);
+}
+
 void kill_child(int sig)
 {
     //SIGKILL

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -109,6 +109,35 @@ public:
     }
 
     /**
+     * Reads the value from the config file
+     * T defines the type of the item (e.g. int, string etc.)
+     *
+     * @param name of the requested item
+     * @param defaultValue value to return when no was found
+     *
+     * @return value from config
+     */
+    template <typename T>
+    static T getConfig(string name, T defaultValue)
+    {
+        iconfigedit *temp = nullptr;
+        iconfig *config = OpenConfig(CONFIG_PATH.c_str(), temp);
+        T returnValue;
+
+        if constexpr(std::is_same<T, std::string>::value)
+        {
+            returnValue = ReadString(config, name.c_str(), ((std::string) defaultValue).c_str());
+        }
+        else if constexpr(std::is_same<T, int>::value)
+        {
+            returnValue = ReadInt(config, name.c_str(), defaultValue);
+        }
+        CloseConfig(config);
+
+        return returnValue;
+    }
+
+    /**
     * Returns an integer representing the download progress
     *
     */

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -15,6 +15,8 @@
 #include "log.h"
 #include <string>
 
+using std::string;
+
 enum class Action
 {
     IWriteSecret,
@@ -25,7 +27,7 @@ enum class Action
     IReadInt
 };
 
-const std::string CONFIG_PATH = CONFIG_FOLDER + "/nextcloud.cfg";
+const std::string CONFIG_PATH = "/mnt/ext1/system/config/nextcloud/nextcloud.cfg";
 
 class Util
 {
@@ -154,6 +156,13 @@ public:
      * @param text text that shall be converted
      */
     static void decodeUrl(std::string &text);
+
+    /**
+     * Encodes an URL
+     *
+     * @param text text that shall be converted
+     */
+    static void encodeUrl(std::string &text);
 
     /**
      * Updates the library of the Pocketbook

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -17,16 +17,6 @@
 
 using std::string;
 
-enum class Action
-{
-    IWriteSecret,
-    IReadSecret,
-    IWriteString,
-    IReadString,
-    IWriteInt,
-    IReadInt
-};
-
 const std::string CONFIG_PATH = "/mnt/ext1/system/config/nextcloud/nextcloud.cfg";
 
 class Util
@@ -52,62 +42,31 @@ public:
     static bool connectToNetwork();
 
     /**
-     * Read and write access to config file
+     * Writes a value to the config
      * T defines the type of the item (e.g. int, string etc.)
      *
-     * @param action option that shall be done
      * @param name of the requested item
-     * @param value that shall be written in case
-     *
-     * @return value that is saved in case
+     * @param value that shall be written
+     * @param secret store the config securely
      */
     template <typename T>
-    static T accessConfig(const Action &action, const std::string &name, T value)
+    static void writeConfig(const std::string &name, T value, bool secret = false)
     {
         iconfigedit *temp = nullptr;
         iconfig *config = OpenConfig(CONFIG_PATH.c_str(), temp);
-        T returnValue;
 
         if constexpr(std::is_same<T, std::string>::value)
         {
-            switch (action)
-            {
-                case Action::IWriteSecret:
-                    WriteSecret(config, name.c_str(), value.c_str());
-                    returnValue = {};
-                    break;
-                case Action::IReadSecret:
-                    returnValue = ReadSecret(config, name.c_str(), "error");
-                    break;
-                case Action::IWriteString:
-                    WriteString(config, name.c_str(), value.c_str());
-                    returnValue = {};
-                    break;
-                case Action::IReadString:
-                    returnValue = ReadString(config, name.c_str(), "error");
-                    break;
-                default:
-                    break;
-            }
+            if (secret) 
+                WriteSecret(config, name.c_str(), value.c_str());
+            else 
+                WriteString(config, name.c_str(), value.c_str());
         }
         else if constexpr(std::is_same<T, int>::value)
         {
-            switch(action)
-            {
-                case Action::IWriteInt:
-                    WriteInt(config, name.c_str(), value);
-                    returnValue = 0;
-                    break;
-                case Action::IReadInt:
-                    returnValue = ReadInt(config, name.c_str(), -1);
-                    break;
-                default:
-                    break;
-            }
+            WriteInt(config, name.c_str(), value);
         }
         CloseConfig(config);
-
-        return returnValue;
     }
 
     /**
@@ -116,11 +75,12 @@ public:
      *
      * @param name of the requested item
      * @param defaultValue value to return when no was found
+     * @param secret load the config from the secure storage
      *
      * @return value from config
      */
     template <typename T>
-    static T getConfig(string name, T defaultValue)
+    static T getConfig(string name, T defaultValue = "error", bool secret = false)
     {
         iconfigedit *temp = nullptr;
         iconfig *config = OpenConfig(CONFIG_PATH.c_str(), temp);
@@ -128,7 +88,10 @@ public:
 
         if constexpr(std::is_same<T, std::string>::value)
         {
-            returnValue = ReadString(config, name.c_str(), ((std::string) defaultValue).c_str());
+            if (secret)
+                returnValue = ReadSecret(config, name.c_str(), defaultValue.c_str());
+            else
+                returnValue = ReadString(config, name.c_str(), ((std::string) defaultValue).c_str());
         }
         else if constexpr(std::is_same<T, int>::value)
         {


### PR DESCRIPTION
This PR adds the function to hide files and folders by a regular expression or by the file extension. These files and folders won't be synced and shown in the UI. This applies for remote, locale and synced files.
Also, the default start folder when opening the app can now be set.

To configure the preferences for hiding files and folders, I've added a new View which is accessible over the main menu when logged in.

<p float="left">
  <img src="https://user-images.githubusercontent.com/77746670/194372378-8f37781e-3787-4e35-b325-ef8206c27096.jpeg" width="350" />
  <img src="https://user-images.githubusercontent.com/77746670/194372384-f206b04e-bef7-45ad-b943-9bdd3d883ea8.jpeg" width="350" /> 
</p>

Some notes to take in mind:

* Added column to `metadata` Table to save the "hidden" state → because of that, a database migration is necessary. So I've created a version table in the SQLite Database to add a migration functionality in the future
* The current (db) version will be set inside the `CMakeLists.txt`
* The exclusion happens currently only on the client. All files and folders will still be fetched from Nextcloud (except the start folder)

Since this was my first experience with *C++* (used only ANSI C for small things in the past), you may want to take a close look to the changes 😊
